### PR TITLE
Added ability to resend verification token to unapproved users

### DIFF
--- a/includes/pages/guest_login.php
+++ b/includes/pages/guest_login.php
@@ -16,12 +16,6 @@ function user_activate_account_title() {
   return _("Activate Account");
 }
 
-// Send verification email
-function send_verification_email($mail, $confirmationToken) {
-  $confirmationTokenUrl = page_link_to_absolute('user_activate_account') . '&token=' . $confirmationToken;
-  engelsystem_email($mail, _('Please confirm your eMail-address'), sprintf(_('Hello %1$s! Thanks for signing up at Engelsystem. Please confirm your eMail-address by clicking the following link: %2$s'), $mail, $confirmationTokenUrl));
-}
-
 // Engel registrieren
 function guest_register() {
   global $default_theme, $genders;
@@ -154,7 +148,7 @@ function guest_register() {
       }
       engelsystem_log("User " . $nick . " signed up as: " . join(", ", $user_angel_types_info));
 
-      send_verification_email($mail, $confirmationToken);      
+      user_send_verification_email($mail, $confirmationToken);      
             
       success(_("Angel registration successful! Please click the confirmation link in the eMail we sent you to activate your account."));
 
@@ -311,47 +305,13 @@ function guest_login() {
           form_password('password', _("Password")),
           form_submit('submit', _("Login")),
           buttons(array(
-              button(page_link_to('user_password_recovery'), _("I forgot my password")) 
+              button(page_link_to('user_password_recovery'), _("I forgot my password")),
+              button(page_link_to('user_resend_verification_token'), _("Request E-Mail verification token")) 
           )),
           info(_("Please note: You have to activate cookies!"), true) 
       )),
       '</div></div>' 
   ));
-}
-
-function guest_resend_verification_token() {  
-  global $user, $privileges;
-
-  $success = false;
-  
-  if(isset($_GET['uid'])) {
-     $uid = $_GET['uid'];
-     if(is_numeric($uid)) {
-       $user = User($uid);
-
-       if($user != null && $user['user_account_approved'] == 0) {
-         // found user entry, check verification bit set? and send email
-         send_verification_email($user['email'], $user['mailaddress_verification_token']);
-
-         success(_("Verification E-Mail was send again to your E-Mail address. If you still don't receive it, please check your spam folder and ask a Dispatcher."));
-         $success = true;
-       }
-     }
-  } 
-
-  $admin_priv = in_array('admin_user', $privileges);
-
-  if($success == false) {
-    // failure, couldn't find user or something went wrong
-    error(_("Verification E-Mail Could not be send. Please ask a Dispatcher."));
-  }
-
-
-  if($admin_priv && $success == true) {
-    redirect(user_link($uid));
-  } else {
-    redirect('?');     
-  }
 }
 
 function user_activate_account_controller () {

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -198,7 +198,7 @@ function User_view($user_source, $admin_user_privilege, $freeloader, $user_angel
           div('col-md-12', array(
               buttons(array(
                   $admin_user_privilege ? button(page_link_to('admin_user') . '&id=' . $user_source['UID'], glyph("edit") . _("edit")) : '',
-                  $admin_user_privilege ? button(page_link_to('user_resend_verification_token') . '&uid=' . $user_source['UID'], glyph("resend verification token") . _("resend verification token")) : '',
+                  ($admin_user_privilege && $user_source['user_account_approved'] == 0) ? button(page_link_to('user_resend_verification_token') . '&uid=' . $user_source['UID'], glyph("resend verification token") . _("resend verification token")) : '',
                   ($admin_user_privilege && ! $user_source['Gekommen']) ? button(page_link_to('admin_arrive') . '&arrived=' . $user_source['UID'], _("available")) : '',
                   $admin_user_privilege ? button(page_link_to('users') . '&action=edit_vouchers&user_id=' . $user_source['UID'], glyph('cutlery') . _('Edit vouchers')) : '',
                   $its_me ? button(page_link_to('user_settings'), glyph('list-alt') . _("Settings")) : '',

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -198,6 +198,7 @@ function User_view($user_source, $admin_user_privilege, $freeloader, $user_angel
           div('col-md-12', array(
               buttons(array(
                   $admin_user_privilege ? button(page_link_to('admin_user') . '&id=' . $user_source['UID'], glyph("edit") . _("edit")) : '',
+                  $admin_user_privilege ? button(page_link_to('user_resend_verification_token') . '&uid=' . $user_source['UID'], glyph("resend verification token") . _("resend verification token")) : '',
                   ($admin_user_privilege && ! $user_source['Gekommen']) ? button(page_link_to('admin_arrive') . '&arrived=' . $user_source['UID'], _("available")) : '',
                   $admin_user_privilege ? button(page_link_to('users') . '&action=edit_vouchers&user_id=' . $user_source['UID'], glyph('cutlery') . _('Edit vouchers')) : '',
                   $its_me ? button(page_link_to('user_settings'), glyph('list-alt') . _("Settings")) : '',

--- a/includes/view/User_view.php
+++ b/includes/view/User_view.php
@@ -251,6 +251,20 @@ function User_password_set_view() {
   ));
 }
 
+/**
+ * View for requesting another eMail verification token
+ */
+function User_request_verification_token_view() {
+  return page_with_title(user_request_verification_token_title(), array(
+      msg(),
+      _("We will resend an e-mail including the verification link. Please use the email address you used for registration."),
+      form(array(
+          form_text('email', _("E-Mail"), ""),
+          form_submit('submit', _("Resend")) 
+      )) 
+  ));
+}
+
 function User_angeltypes_render($user_angeltypes) {
   $output = array();
   foreach ($user_angeltypes as $angeltype) {

--- a/public/index.php
+++ b/public/index.php
@@ -9,6 +9,7 @@ PN_ShowNotice('?p=privacy');
 $free_pages = array(
     'stats',
     'shifts_json_export_all',
+    'user_resend_verification_token',
     'user_password_recovery',
     'user_activate_account',
     'api',
@@ -58,6 +59,9 @@ if (isset($_REQUEST['p'])
       } elseif ($p == "stats") {
         require_once realpath(__DIR__ . '/../includes/pages/guest_stats.php');
         guest_stats();
+      } elseif ($p == "user_resend_verification_token") {
+        require_once realpath(__DIR__. '/../includes/pages/guest_login.php');
+        guest_resend_verification_token();
       } elseif ($p == "user_password_recovery") {
         require_once realpath(__DIR__ . '/../includes/controller/users_controller.php');
         $title = user_password_recovery_title();

--- a/public/index.php
+++ b/public/index.php
@@ -60,8 +60,8 @@ if (isset($_REQUEST['p'])
         require_once realpath(__DIR__ . '/../includes/pages/guest_stats.php');
         guest_stats();
       } elseif ($p == "user_resend_verification_token") {
-        require_once realpath(__DIR__. '/../includes/pages/guest_login.php');
-        guest_resend_verification_token();
+        $title = user_request_verification_token_title();
+        $content = user_resend_verification_token();
       } elseif ($p == "user_password_recovery") {
         require_once realpath(__DIR__ . '/../includes/controller/users_controller.php');
         $title = user_password_recovery_title();


### PR DESCRIPTION
Based on issue https://github.com/welcomehelpde/engelsystem/issues/41 :

Added:
1) p=user&action=view&uid=???: in case the viewing user is an admin a button to the list of buttons that allows to resend the verification token
2) p=login: on login failure (correct login information (user + password), but account not approved), show a different error message that includes a link to resend the verification token
3) General function to resend verification token based on a user id p=resend_verification_token (taking one argument uid). its visible to all.