### PR TITLE
added smtp_transport configuration to config file + usage in email helper

### DIFF
--- a/config/config-dist.php
+++ b/config/config-dist.php
@@ -9,6 +9,8 @@ $config = array(
 
 // STMP Mailserver Config
 $mailConfig['smtp_host'] = '';
+$mailConfig['smtp_port'] = '';
+$mailConfig['smtp_transport'] = '';
 $mailConfig['smtp_user'] = '';
 $mailConfig['smtp_password'] = '';
 $mailConfig['sender_address'] = '';

--- a/includes/helper/email_helper.php
+++ b/includes/helper/email_helper.php
@@ -17,7 +17,7 @@ function engelsystem_email_to_user($recipient_user, $title, $message, $not_if_it
 function engelsystem_email($recipient, $subject, $body) {
   global $mailConfig;
 
-  $transport = Swift_SmtpTransport::newInstance($mailConfig['smtp_host'], $mailConfig['smtp_port'])
+  $transport = Swift_SmtpTransport::newInstance($mailConfig['smtp_host'], $mailConfig['smtp_port'], $mailConfig['smtp_transport'])
     ->setUsername($mailConfig['smtp_user'])
     ->setPassword($mailConfig['smtp_password']);
   $mailer = Swift_Mailer::newInstance($transport);


### PR DESCRIPTION
see issue https://github.com/welcomehelpde/engelsystem/issues/59

makes transport type configurable in config file. Installed OpenSSL needs to support the configured transport mode.

Tested using TLS SMTP. 