### PR TITLE
#15 implemented "shift manager" display

### DIFF
--- a/includes/controller/shifts_controller.php
+++ b/includes/controller/shifts_controller.php
@@ -153,4 +153,20 @@ function shifts_json_export_controller() {
   die();
 }
 
+function getShiftManagers($shiftId) {
+  $sql = 'SELECT `User`.`Vorname`, `User`.`Name`, `User`.`Handy`
+          FROM `ShiftEntry`
+
+          LEFT JOIN `AngelTypes`
+          ON `ShiftEntry`.`TID` = `AngelTypes`.`id`
+          AND `AngelTypes`.`name` LIKE "%Schichtleiter%"
+
+          LEFT JOIN `USER`
+          ON `ShiftEntry`.`UID` = `User`.`UID`
+
+          WHERE `ShiftEntry`.`SID` = "' . $shiftId . '"';
+
+    return sql_select($sql);
+}
+
 ?>

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -584,6 +584,11 @@ function view_user_shifts() {
                 $shifts_row .= $shift['title'];
                 $shifts_row .= "<br />";
               }
+
+              $shifts_row .= _('Shift Manager') . ': ' . implode(', ', array_map(function ($manager) {
+                return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+              }, getShiftManagers($shift['SID'])));
+
               $shifts_row .= '</a>';
               $shifts_row .= '<br />';
               $query = "SELECT `NeededAngelTypes`.`count`, `AngelTypes`.`id`, `AngelTypes`.`restricted`, `UserAngelTypes`.`confirm_user_id`, `AngelTypes`.`name`, `UserAngelTypes`.`user_id`
@@ -710,6 +715,14 @@ function view_user_shifts() {
           'info' => join('<br />', $info),
           'entries' => '<a href="' . shift_link($shift) . '">' . $shift['name'] . '</a>' . ($shift['title'] ? '<br />' . $shift['title'] : '')
       );
+
+      $shiftManagers = getShiftManagers($shift['SID']);
+      if(!empty($shiftManagers)) {
+        $shift_row['entries'] .= '<br>' . _('Shift Manager')  . ': ';
+        $shift_row['entries'] .= implode(', ', array_map(function ($manager) {
+          return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+        }, $shiftManagers));
+      }
 
       if (in_array('admin_shifts', $privileges))
         $shift_row['info'] .= ' ' . table_buttons(array(

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -111,8 +111,12 @@ function Shift_view($shift, $shifttype, $room, $shift_admin, $angeltypes_source,
               '<div class="list-group">' . $needed_angels . '</div>' 
           ]),
           div('col-sm-6', [
+              '<h2>' . _('Shift Manager') . '</h2>',
+              implode('<br>', array_map(function ($manager) {
+                        return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+                      }, getShiftManagers($shift['SID']))),
               '<h2>' . _('Description') . '</h2>',
-              $parsedown->parse($shifttype['description']) 
+              $parsedown->parse($shifttype['description'])
           ]) 
       ]),
       $shift_admin ? Shift_editor_info_render($shift) : '' 


### PR DESCRIPTION
* Schichtleiter werden anhand des "Helfer-Typs" identifiziert: Sobald im Helfertyp das Wort "Schichtleiter" vorkommt, gilt er als Schichtleiter ("Schichtleiter Welcomezelt" z.B. würde also auch funktionieren).
* Es kann mehrere Schichtleiter geben (auch wenn das in der Praxis vielleicht nicht vorkommt) - Diese werden kann neben- bzw. untereinander angezeigt.
* Die Informationen werden an drei Stellen angezeigt: Schicht-Plan als "Kalender", Schicht-Plan als Liste, Schicht-Details
* Angezeigt werden immer Vor- und Nachname, wenn vorhanden auch Handy.