### PR TITLE
implemented "shift manager" display

### DIFF
--- a/includes/controller/shifts_controller.php
+++ b/includes/controller/shifts_controller.php
@@ -159,12 +159,12 @@ function getShiftManagers($shiftId) {
 
           LEFT JOIN `AngelTypes`
           ON `ShiftEntry`.`TID` = `AngelTypes`.`id`
-          AND `AngelTypes`.`name` LIKE "%Schichtleiter%"
-
+          
           LEFT JOIN `User`
           ON `ShiftEntry`.`UID` = `User`.`UID`
 
-          WHERE `ShiftEntry`.`SID` = "' . $shiftId . '"';
+          WHERE `ShiftEntry`.`SID` = "' . $shiftId . '"
+          AND `AngelTypes`.`name` LIKE "%Schichtleiter%"';
 
     return sql_select($sql);
 }

--- a/includes/controller/shifts_controller.php
+++ b/includes/controller/shifts_controller.php
@@ -153,4 +153,20 @@ function shifts_json_export_controller() {
   die();
 }
 
+function getShiftManagers($shiftId) {
+  $sql = 'SELECT `User`.`Vorname`, `User`.`Name`, `User`.`Handy`
+          FROM `ShiftEntry`
+
+          LEFT JOIN `AngelTypes`
+          ON `ShiftEntry`.`TID` = `AngelTypes`.`id`
+          AND `AngelTypes`.`name` LIKE "%Schichtleiter%"
+
+          LEFT JOIN `USER`
+          ON `ShiftEntry`.`UID` = `User`.`UID`
+
+          WHERE `ShiftEntry`.`SID` = "' . $shiftId . '"';
+
+    return sql_select($sql);
+}
+
 ?>

--- a/includes/controller/shifts_controller.php
+++ b/includes/controller/shifts_controller.php
@@ -161,7 +161,7 @@ function getShiftManagers($shiftId) {
           ON `ShiftEntry`.`TID` = `AngelTypes`.`id`
           AND `AngelTypes`.`name` LIKE "%Schichtleiter%"
 
-          LEFT JOIN `USER`
+          LEFT JOIN `User`
           ON `ShiftEntry`.`UID` = `User`.`UID`
 
           WHERE `ShiftEntry`.`SID` = "' . $shiftId . '"';

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -585,9 +585,12 @@ function view_user_shifts() {
                 $shifts_row .= "<br />";
               }
 
-              $shifts_row .= _('Shift Manager') . ': ' . implode(', ', array_map(function ($manager) {
-                return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
-              }, getShiftManagers($shift['SID'])));
+              $shiftManagers = getShiftManagers($shift['SID']);
+              if(!empty($shiftManagers)) {
+                $shifts_row .= _('Shift Manager') . ': ' . implode(', ', array_map(function ($manager) {
+                  return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+                }, $shiftManagers));
+              }
 
               $shifts_row .= '</a>';
               $shifts_row .= '<br />';

--- a/includes/pages/user_shifts.php
+++ b/includes/pages/user_shifts.php
@@ -584,6 +584,11 @@ function view_user_shifts() {
                 $shifts_row .= $shift['title'];
                 $shifts_row .= "<br />";
               }
+
+              $shifts_row .= _('Shift Manager') . ': ' . implode(', ', array_map(function ($manager) {
+                return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+              }, getShiftManagers($shift['SID'])));
+
               $shifts_row .= '</a>';
               $shifts_row .= '<br />';
               $query = "SELECT `NeededAngelTypes`.`count`, `AngelTypes`.`id`, `AngelTypes`.`restricted`, `UserAngelTypes`.`confirm_user_id`, `AngelTypes`.`name`, `UserAngelTypes`.`user_id`
@@ -710,6 +715,14 @@ function view_user_shifts() {
           'info' => join('<br />', $info),
           'entries' => '<a href="' . shift_link($shift) . '">' . $shift['name'] . '</a>' . ($shift['title'] ? '<br />' . $shift['title'] : '')
       );
+
+      $shiftManagers = getShiftManagers($shift['SID']);
+      if(!empty($shiftManagers)) {
+        $shift_row['entries'] .= '<br>' . _('Shift Manager')  . ': ';
+        $shift_row['entries'] .= implode(', ', array_map(function ($manager) {
+          return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+        }, $shiftManagers));
+      }
 
       if (in_array('admin_shifts', $privileges))
         $shift_row['info'] .= ' ' . table_buttons(array(

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -111,8 +111,12 @@ function Shift_view($shift, $shifttype, $room, $shift_admin, $angeltypes_source,
               '<div class="list-group">' . $needed_angels . '</div>' 
           ]),
           div('col-sm-6', [
+              '<h2>' . _('Shift Manager') . '</h2>',
+              implode('<br>', array_map(function ($manager) {
+                        return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
+                      }, getShiftManagers($shift['SID']))),
               '<h2>' . _('Description') . '</h2>',
-              $parsedown->parse($shifttype['description']) 
+              $parsedown->parse($shifttype['description'])
           ]) 
       ]),
       $shift_admin ? Shift_editor_info_render($shift) : '' 

--- a/includes/view/Shifts_view.php
+++ b/includes/view/Shifts_view.php
@@ -68,6 +68,7 @@ function Shift_view($shift, $shifttype, $room, $shift_admin, $angeltypes_source,
     $needed_angels .= '</div>';
   }
   
+  $shiftManagers = getShiftManagers($shift['SID']);
   return page_with_title($shift['name'] . ' <small class="moment-countdown" data-timestamp="' . $shift['start'] . '">%c</small>', [
       
       msg(),
@@ -111,10 +112,11 @@ function Shift_view($shift, $shifttype, $room, $shift_admin, $angeltypes_source,
               '<div class="list-group">' . $needed_angels . '</div>' 
           ]),
           div('col-sm-6', [
-              '<h2>' . _('Shift Manager') . '</h2>',
-              implode('<br>', array_map(function ($manager) {
+              !empty($shiftManagers) ? '<h2>' . _('Shift Manager') . '</h2>' : '',
+              !empty($shiftManagers) ? implode('<br>', array_map(function ($manager) {
                         return $manager['Vorname'] . ' ' . $manager['Name'] . ($manager['Handy'] ? ' (Handy: ' . $manager['Handy'] . ')' : '');
-                      }, getShiftManagers($shift['SID']))),
+                      }, $shiftManagers)) : '',
+              
               '<h2>' . _('Description') . '</h2>',
               $parsedown->parse($shifttype['description'])
           ]) 


### PR DESCRIPTION
* Schichtleiter werden anhand des "Helfer-Typs" identifiziert: Sobald im Helfertyp das Wort "Schichtleiter" vorkommt, gilt er als Schichtleiter ("Schichtleiter Welcomezelt" z.B. würde also auch funktionieren).
* Es kann mehrere Schichtleiter geben (auch wenn das in der Praxis vielleicht nicht vorkommt) - Diese werden kann neben- bzw. untereinander angezeigt.
* Die Informationen werden an drei Stellen angezeigt: Schicht-Plan als "Kalender", Schicht-Plan als Liste, Schicht-Details
* Angezeigt werden immer Vor- und Nachname, wenn vorhanden auch Handy.